### PR TITLE
Agrega configuración de mailer usando sendgrid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,8 +89,13 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'san-saru.herokuapp.com' }
-  Rails.application.routes.default_url_options[:host] = 'san-saru.herokuapp.com'
+  host = ENV.fetch('APP_HOST', 'https://sansarud4g.herokuapp.com')
+  user_name = ENV.fetch('SENDGRID_USERNAME', ENV['MAIL_USERNAME'])
+  password = ENV.fetch('SENDGRID_PASSWORD', ENV['MAIL_PASSWORD'])
+  address = ENV.fetch('SENDGRID_ADDRESS', ENV['SMTP_ADDR'])
+
+  config.action_mailer.default_url_options = { host: host }
+  Rails.application.routes.default_url_options[:host] = host
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
@@ -98,12 +103,12 @@ Rails.application.configure do
   config.action_mailer.default charset: 'utf-8'
 
   config.action_mailer.smtp_settings = {
-    address: ENV['SMTP_ADDR'],
+    address: address,
     port: 587,
-    domain: ENV['MAIL_DOMAIN'],
+    domain: host,
     authentication: 'plain',
     enable_starttls_auto: true,
-    user_name: ENV['MAIL_USERNAME'],
-    password: ENV['MAIL_PASSWORD']
+    user_name: user_name,
+    password: password
   }
 end


### PR DESCRIPTION
La app deployada en heroku está usando **Sendgrid**, un plugin con plan free para enviar mails.
En la configuración del mailer de producción, agrego algunas variables de ambiente que Sendgrid provee para que sea posible enviar mails. En caso de que estas variables no estén presentes en la configuración de producción, vamos a recaer en las variables de ambiente `MAIL_USERNAME, MAIL_PASSWORD, SMTP_ADDR`.

Cambié el host de la aplicación que estaba mal y lo moví a una variable de ambiente para que sea configurable desde heroku.

Queda pendiente cambiar el valor de la variable de ambiente `MAIL_USERNAME` en heroku (desde acá https://dashboard.heroku.com/apps/sansarud4g/settings) a una dirección de mail (emisor) correcta, actualmente le puse `developersforgood@gmail.com` pero gmail parece no detectarlo como válido entonces manda los mails a **spam**.